### PR TITLE
NULL Parameter Check Before Type Compare

### DIFF
--- a/src/edge-sql/EdgeCompiler.cs
+++ b/src/edge-sql/EdgeCompiler.cs
@@ -55,7 +55,7 @@ public class EdgeCompiler
         {
             foreach (KeyValuePair<string, object> parameter in parameters)
             {
-                if (parameter.Value.GetType() == typeof(ExpandoObject))
+                if (parameter.Value != null && parameter.Value.GetType() == typeof(ExpandoObject))
                 {
                     if (((IDictionary<string, object>)parameter.Value).ContainsKey("UdtType"))
                     {


### PR DESCRIPTION
To allow NULL parameters to be used in queries/procs (update to 0.1.2) parameter values null check is done before (Value.GetType) is called.
