### PR TITLE
Allow empty record sets with multiple return sets

### DIFF
--- a/src/edge-sql/EdgeCompiler.cs
+++ b/src/edge-sql/EdgeCompiler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Threading.Tasks;
@@ -147,7 +147,8 @@ public class EdgeCompiler
         using (SqlDataReader reader = await command.ExecuteReaderAsync(CommandBehavior.CloseConnection))
         {
             IDataRecord record = (IDataRecord)reader;
-            while (reader.HasRows)
+            // try to process all result sets, even if they are empty
+            while (true)
             {
                 List<object> rows = new List<object>();
                 while (await reader.ReadAsync())
@@ -184,7 +185,8 @@ public class EdgeCompiler
 
                 recordsets.Add(rows);
 
-                reader.NextResult();
+                // Break if no more results
+                if (!reader.NextResult()) break;
             }
 
             if (recordsets.Count == 1)


### PR DESCRIPTION
When returning multiple record sets having any record set besides the last would result in the premature termination of the results parsing.  Corrected by checking for additional record sets and only exiting the loop when none were found.  Tested with single record set returns, no record set returns and multiple record set returns with no empties, and empties in first, last and middle positions.
